### PR TITLE
fix: add retry to getIntegrity to account for verdaccio file write delay

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import path from 'path'
 import execa from 'execa'
 import { sync as readYamlFile } from 'read-yaml-file'
@@ -47,10 +46,38 @@ export const addDistTag = _addDistTag(REGISTRY_MOCK_PORT)
 export const addUser = _addUser(REGISTRY_MOCK_PORT)
 
 export const getIntegrity = (pkgName: string, pkgVersion: string): string => {
-  return JSON.parse(fs.readFileSync(
-    path.join(locations.storage(), pkgName, 'package.json'),
-    'utf8'
-  )).versions[pkgVersion].dist.integrity
+  const filePath = path.join(locations.storage(), pkgName, 'package.json')
+  const maxRetries = 4
+  let delay = 200 // milliseconds
+  let content: any
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      content = fsx.readJSONSync(filePath)
+      break
+    } catch (err) {
+      if (attempt === maxRetries ||
+        !err ||
+        typeof err !== 'object' ||
+        (
+          !(err instanceof SyntaxError && err.message.endsWith('Unexpected end of JSON input')) &&
+          (err as NodeJS.ErrnoException).code !== 'ENOENT'
+        )
+      ) {
+        throw err
+      }
+      // If verdaccio downloads a package from the uplink registry because it wasn't present, it
+      // will respond to the HTTP request before it finishes writing the package.json file to the
+      // storage directory. There is also a window where the package.json file may exist but be empty 
+      // (see https://github.com/verdaccio/verdaccio/blob/ae0dbff9a549216bf54a0e1646db6bb743a0c960/packages/plugins/local-storage/src/local-fs.ts#L174-L187).
+      // To handle this gracefully, retry reading the file with an exponential backoff strategy if
+      // we encounter a syntax error or file not found error.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay)
+      delay *= 2
+    }
+  }
+  // content should always be defined here, but check just in case
+  if (!content) throw new Error(`Failed to read package.json for ${pkgName}@${pkgVersion} after ${maxRetries} attempts`)
+  return content.versions[pkgVersion].dist.integrity
 }
 
 export { REGISTRY_MOCK_PORT }


### PR DESCRIPTION
When verdaccio downloads a package from the uplink registry, it responds to the HTTP request before it finishes writing the package to storage. This can cause `getIntegrity` to fail if it's called too soon after the HTTP request finishes.

This adds retry logic with exponential backoff to handle this issue gracefully. Also switches from manual `fs.readFileSync` + `JSON.parse` to `fsx.readJSONSync`.

This should help reduce flaky tests in the pnpm repo. An example of a failed flaky test because of this issue is below:

```
  FAIL test/storeAdd.ts
    ● pnpm store add express@4.16.3
  
      ENOENT: no such file or directory, open 'C:\Users\RUNNER~1\AppData\Local\Temp\e9eb9d272ba7e772737856b7f0c917a9\express\package.json'
  
        24 |   const store = {
        25 |     getPkgIndexFilePath (pkgName: string, version: string): string {
      > 26 |       const integrity = getIntegrity(pkgName, version)
           |                         ^
        27 |       return getIndexFilePathInCafs(storePath, integrity, `${pkgName}@${version}`)
        28 |     },
        29 |     cafsHas (pkgName: string, version: string): void {
  
        at getIntegrity (../../node_modules/.pnpm/@pnpm+registry-mock@5.2.1_v_8cb75d16396c3d8a51e8640c1af4e44c/node_modules/@pnpm/registry-mock/src/index.ts:50:24)
        at Object.getIntegrity [as getPkgIndexFilePath] (../../__utils__/assert-store/src/index.ts:26:25)
        at getPkgIndexFilePath (../../__utils__/assert-store/src/index.ts:30:33)
        at Object.<anonymous> (test/storeAdd.ts:30:3)
```

Source: https://github.com/jasonpaulos/pnpm/actions/runs/22107419045/job/63894712661